### PR TITLE
Fix typos in README that suggests the wrong keyslots

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This tool allows you to encrypt and decrypt your personally dumped NDS and N3DS 
 You are! In fact, you may be asking, "Hey, what was that `keys.bin` you mentioned??". I'm glad you asked. It's used only for Nintendo 3DS and New 3DS files. Since some people don't like reading code, you need the 9 16-bit keys in little endian format (most common extraction methods produce big endian, so keep that in mind). It's recommended that you fill with 0x00 if you don't have access to a particular value so it doesn't mess up the read. They need to be in the following order:
 
 - Hardware constant
-- KeyX0x10
+- KeyX0x18
 - KeyX0x1B
 - KeyX0x25
 - KeyX0x2C

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You are! In fact, you may be asking, "Hey, what was that `keys.bin` you mentione
 - KeyX0x1B
 - KeyX0x25
 - KeyX0x2C
-- DevKeyX0x10
+- DevKeyX0x18
 - DevKeyX0x1B
 - DevKeyX0x25
 - DevKeyX0x2C


### PR DESCRIPTION
The README lists `KeyX0x10` as required, when it's actually `KeyX0x18`